### PR TITLE
Add get_version_info tool + CI workflow (v0.1.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-asyncio
+
+      - name: Run unit tests (L2)
+        run: python -m pytest tests/test_tools.py -v
+
+      - name: Run security tests
+        run: python -m pytest tests/test_security.py -v
+
+  ci-all-green:
+    name: ci-all-green
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify required jobs all succeeded
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "FAIL: test matrix did not all succeed (result=${{ needs.test.result }})"
+            exit 1
+          fi
+          echo "All required CI jobs passed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `n1mm-mcp` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.5] — 2026-05-16
+
+### Added
+- New tool `get_version_info` — returns `{service_name, service_version, spec_version}`
+  for fleet identity attestation. Tracks [IONIS-AI/ionis-devel#49](https://github.com/IONIS-AI/ionis-devel/issues/49).
+- `__spec_version__` pinned to `n1mm-udp-v1`.
+- L2 unit tests N1MM-L2-041 through N1MM-L2-045.
+- `.github/workflows/ci.yml` — PR-gating CI (py3.10-3.13 matrix).
+
+### Changed
+- `__init__.py` modernized to fleet pattern (`Final` types).
+- `get_version_info` complements (but does not replace) `n1mm_diagnostics`
+  — diagnostics stays the canonical health probe (heartbeat, parse errors,
+  memory). get_version_info is the lighter-weight identity attestation
+  that succeeds even when N1MM isn't broadcasting.
+
+## [0.1.4] — Previous release
+- See git history for changes prior to the changelog being introduced.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pip install n1mm-mcp
 | `n1mm_multipliers` | Mult grid, needs, value analysis |
 | `n1mm_clock` | Contest timing, off-time, pacing |
 | `n1mm_diagnostics` | Server health, parse errors, memory |
+| `get_version_info` | Service version + upstream UDP contract version (fleet identity attestation) |
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "n1mm-mcp"
-version = "0.1.4"
+version = "0.1.5"
 description = "MCP server for N1MM Logger+ — live contest state via UDP broadcast"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/n1mm_mcp/__init__.py
+++ b/src/n1mm_mcp/__init__.py
@@ -1,8 +1,19 @@
 """n1mm-mcp — MCP server for N1MM Logger+ contest state via UDP broadcast."""
 
-try:
-    from importlib.metadata import version
+from __future__ import annotations
 
-    __version__ = version("n1mm-mcp")
-except Exception:
-    __version__ = "0.0.0-dev"
+from importlib.metadata import PackageNotFoundError, version
+from typing import Final
+
+try:
+    _pkg_version = version("n1mm-mcp")
+except PackageNotFoundError:  # local dev / editable installs without dist metadata
+    _pkg_version = "0.0.0-dev"
+
+__version__: Final[str] = _pkg_version
+
+# Upstream data spec the server is bound to. Pinned to the N1MM Logger+
+# UDP broadcast contract revision we consume — bump this when N1MM
+# changes its UDP message format. Reported by the get_version_info tool
+# so agents can detect fleet drift without going outside the MCP protocol.
+__spec_version__: Final[str] = "n1mm-udp-v1"

--- a/src/n1mm_mcp/server.py
+++ b/src/n1mm_mcp/server.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 
-from . import __version__
+from . import __spec_version__, __version__
 from .frequency import freq_to_band, from_spot_freq, from_tens_hz
 from .state import (
     DEFAULT_HEARTBEAT_TIMEOUT,
@@ -77,6 +77,45 @@ def _radio_to_dict(radio) -> dict[str, Any]:
         "radio_name": radio.radio_name,
         "active_radio_nr": radio.active_radio_nr,
     }
+
+
+# ---------------------------------------------------------------------------
+# Tool 0: get_version_info — Fleet Identity Attestation
+# ---------------------------------------------------------------------------
+
+
+def _version_info_payload() -> dict[str, Any]:
+    """Build the version info envelope. Pulled into a helper so tests can
+    call it directly without going through the FastMCP wrapper.
+
+    This is the only tool that doesn't touch the UDP listener state —
+    useful as an operator self-check when N1MM isn't broadcasting.
+    """
+    return {
+        "service_name": "n1mm-mcp",
+        "service_version": __version__,
+        "spec_version": __spec_version__,
+    }
+
+
+@mcp.tool()
+def get_version_info() -> dict[str, Any]:
+    """Get n1mm-mcp service version and upstream UDP contract version.
+
+    Returns the running PyPI version of n1mm-mcp and the N1MM Logger+
+    UDP broadcast contract revision in use. Use this to confirm fleet
+    alignment across MCP deployments — agents can compare service_version
+    and spec_version across servers to detect drift without going outside
+    the MCP protocol.
+
+    Note: n1mm_diagnostics remains the canonical health probe (heartbeat,
+    parse errors, memory). get_version_info is a lighter-weight identity
+    attestation that succeeds even when N1MM isn't broadcasting.
+
+    Returns:
+        service_name, service_version (PyPI), and spec_version (UDP contract).
+    """
+    return _version_info_payload()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -251,3 +251,53 @@ class TestIntegration:
         assert freq_to_band(14.0) == "20m"
         assert freq_to_band(14.35) == "20m"
         assert freq_to_band(13.99) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# N1MM-L2-041..045: get_version_info — fleet identity attestation
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersionInfo:
+    """Tracks IONIS-AI/ionis-devel#49 — fleet get_version_info convention.
+
+    These tests don't need the UDP listener — get_version_info is the only
+    tool that returns pure metadata without consulting StateEngine. Tests
+    pin that contract.
+    """
+
+    def test_returns_service_name(self):
+        """N1MM-L2-041: payload includes service_name = 'n1mm-mcp'."""
+        from n1mm_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["service_name"] == "n1mm-mcp"
+
+    def test_returns_service_version(self):
+        """N1MM-L2-042: service_version matches package __version__."""
+        from n1mm_mcp import __version__
+        from n1mm_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["service_version"] == __version__
+
+    def test_returns_spec_version(self):
+        """N1MM-L2-043: spec_version pins the N1MM UDP contract."""
+        from n1mm_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["spec_version"] == "n1mm-udp-v1"
+
+    def test_payload_keys_are_required_set(self):
+        """N1MM-L2-044: payload has the required keys (no extras yet)."""
+        from n1mm_mcp.server import _version_info_payload
+
+        result = _version_info_payload()
+        required = {"service_name", "service_version", "spec_version"}
+        assert required.issubset(set(result.keys()))
+
+    def test_all_values_are_strings(self):
+        """N1MM-L2-045: all returned values are strings (JSON-safe envelope)."""
+        from n1mm_mcp.server import _version_info_payload
+
+        result = _version_info_payload()
+        for k in ("service_name", "service_version", "spec_version"):
+            assert isinstance(result[k], str), f"{k} should be str, got {type(result[k])}"
+            assert result[k], f"{k} should be non-empty"


### PR DESCRIPTION
Fleet rollout per [IONIS-AI/ionis-devel#49](https://github.com/IONIS-AI/ionis-devel/issues/49). Twelfth and final server. Envelope: `{service_name, service_version, spec_version=n1mm-udp-v1}`. 5 new tests (N1MM-L2-041..045). get_version_info complements (does not replace) n1mm_diagnostics — diagnostics stays as canonical health probe.